### PR TITLE
Recursive Paths (separated by /)

### DIFF
--- a/src/commands/config/delete.ts
+++ b/src/commands/config/delete.ts
@@ -54,7 +54,7 @@ Deletes configuration entries across multiple stages.`
         entries.map(async (entry: string) => {
           await ssm
             .deleteParameter({
-              Name: RemoteConfigurationPath.pathFromKey(entry, stage, this.cfg),
+              Name: RemoteConfigurationPath.pathFromKey(entry, stage, this.cfg, true),
             })
             .promise()
 

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -54,7 +54,7 @@ Get configuration entries from multiple stages.`
         entries.map(async (entry: string) => {
           const value = await ssm
             .getParameter({
-              Name: RemoteConfigurationPath.pathFromKey(entry, stage, this.cfg),
+              Name: RemoteConfigurationPath.pathFromKey(entry, stage, this.cfg, true),
             })
             .promise()
 

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -54,7 +54,7 @@ Set configuration entries from multiple stages.`
   async setConfigValues(stages: string[], entries: RemoteConfigurationEntry[]) {
     const transformedValues: RemoteConfigurationEntry[] = entries.map((entry) => {
       // Sanitizing input.
-      entry.key = kebabCase(entry.key)
+      entry.key = RemoteConfigurationPath.pathFromKey(entry.key)
       return entry
     })
 
@@ -70,7 +70,7 @@ Set configuration entries from multiple stages.`
         return transformedValues.map(async (entry: RemoteConfigurationEntry) => {
           await ssm
             .putParameter({
-              Name: RemoteConfigurationPath.pathFromKey(entry.key, stage, this.cfg),
+              Name: RemoteConfigurationPath.pathFromKey(entry.key, stage, this.cfg, true),
               Description: entry.description || '',
               Value: entry.value,
               Type: entry.type || 'String',


### PR DESCRIPTION
- When exporting to dotenv, we transform the slash from the SSM path to `__` instead of a single `_`. This will be important when we allow importing from dotenv as well
- Now values can be set as a path: `matter config:set -e foo/bar/baz=value` for example.