### PR TITLE
feat: Added ability to send "" as values

### DIFF
--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -2,7 +2,7 @@ import { flatMap } from 'lodash'
 import { flags } from '@oclif/command'
 import * as chalk from 'chalk'
 import { BaseCommand } from '../../command'
-import { RemoteConfigurationPath } from '../../remote-config'
+import { RemoteConfigurationPath, RemoteConfigurationValue } from '../../remote-config'
 import { createSSMConfigManager } from '../../aws'
 
 export class GetCommand extends BaseCommand {
@@ -59,7 +59,9 @@ Get configuration entries from multiple stages.`
             .promise()
 
           this.log(
-            `Value ${chalk.green.bold(entry)} = ${chalk.green(value.Parameter?.Value)} (${stage})`
+            `Value ${chalk.green.bold(entry)} = ${chalk.green(
+              RemoteConfigurationValue.parseConfigValue(value.Parameter?.Value, this.cfg)
+            )} (${stage})`
           )
         })
       )

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -2,7 +2,11 @@ import { kebabCase, flatMap } from 'lodash'
 import { flags } from '@oclif/command'
 import * as chalk from 'chalk'
 import { BaseCommand } from '../../command'
-import { RemoteConfigurationEntry, RemoteConfigurationPath } from '../../remote-config'
+import {
+  RemoteConfigurationEntry,
+  RemoteConfigurationPath,
+  RemoteConfigurationValue,
+} from '../../remote-config'
 import { createSSMConfigManager } from '../../aws'
 
 export class SetCommand extends BaseCommand {
@@ -55,6 +59,8 @@ Set configuration entries from multiple stages.`
     const transformedValues: RemoteConfigurationEntry[] = entries.map((entry) => {
       // Sanitizing input.
       entry.key = RemoteConfigurationPath.pathFromKey(entry.key)
+      entry.value = RemoteConfigurationValue.formatEntryValue(entry.value)
+
       return entry
     })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,10 @@ import { get, defaultsDeep } from 'lodash'
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
 import * as chalk from 'chalk'
-import * as path from 'path'
 import * as findUp from 'findup-sync'
+
+// This is because SSM does not support empty values.
+export const NULL_VALUE = `NULL`
 
 export const MATTER_CONFIG_PATH = `.matter`
 export const MATTER_CONFIG_FILENAME = `config.yml`


### PR DESCRIPTION
AWS SSM doesn't allow empty values to be sent. This PR adds the ability to send "" as a value, which is then translated to NULL in AWS. On the way out, NULL is transformed back to an empty values.